### PR TITLE
Fixnum deprecated, use Integer instead

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -24,7 +24,7 @@ module WillPaginate
       # method as you see fit.
       def to_html
         html = pagination.map do |item|
-          item.is_a?(Fixnum) ?
+          item.is_a?(Integer) ?
             page_number(item) :
             send(item)
         end.join(@options[:link_separator])
@@ -88,7 +88,7 @@ module WillPaginate
       end
 
       def link(text, target, attributes = {})
-        if target.is_a? Fixnum
+        if target.is_a? Integer
           attributes[:rel] = rel_value(target)
           target = url(target)
         end


### PR DESCRIPTION
Per https://bugs.ruby-lang.org/issues/12739, ::Fixnum & ::Bignum are deprecated